### PR TITLE
Fix(lumenfall): Add missing es-module-shims polyfill

### DIFF
--- a/lumenfall/index.html
+++ b/lumenfall/index.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=Inter&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
+    <script async src="https://unpkg.com/es-module-shims@1.6.3/dist/es-module-shims.js"></script>
     <script type="importmap">
     {
       "imports": {


### PR DESCRIPTION
The refactored LumenFall game was failing to load because the `lumenfall/index.html` file was missing the `es-module-shims.js` polyfill. This script is necessary to ensure that ES modules and import maps are supported across all browsers.

This commit adds the missing script tag, which should allow the JavaScript modules to be imported correctly and the game to load as intended.