### PR TITLE
feat: Add door sound effect

### DIFF
--- a/lumenfall/js/game.js
+++ b/lumenfall/js/game.js
@@ -189,6 +189,7 @@
                                     spawnX = targetGate.x;
                                 }
                             }
+                            playAudio('puerta');
                             triggerTransition(destinationId, spawnX);
                         } else if (interactableObject.type === 'puzzle') {
                             interactableObject.object.solve();
@@ -350,7 +351,8 @@
             try {
                 await Promise.all([
                     loadAudio('pasos', '../assets/mp3/LUMENFALL/Pasos-Joziel.mp3'),
-                    loadAudio('ambiente', '../assets/mp3/LUMENFALL/calabozo_de_piedra.mp3')
+                    loadAudio('ambiente', '../assets/mp3/LUMENFALL/calabozo_de_piedra.mp3'),
+                    loadAudio('puerta', '../assets/audio/puerta-calabozo.mp3')
                 ]);
             } catch (error) {
                 console.error("Error loading audio", error);


### PR DESCRIPTION
This commit adds the sound effect for the dungeon doors.

- The `puerta-calabozo.mp3` audio file is now loaded when the game starts.
- The sound is played whenever the player interacts with a gate to transition to a new level.