### PR TITLE
fix: Correct door sound audio path

### DIFF
--- a/lumenfall/js/game.js
+++ b/lumenfall/js/game.js
@@ -352,7 +352,7 @@
                 await Promise.all([
                     loadAudio('pasos', '../assets/mp3/LUMENFALL/Pasos-Joziel.mp3'),
                     loadAudio('ambiente', '../assets/mp3/LUMENFALL/calabozo_de_piedra.mp3'),
-                    loadAudio('puerta', '../assets/audio/puerta-calabozo.mp3')
+                    loadAudio('puerta', 'assets/audio/puerta-calabozo.mp3')
                 ]);
             } catch (error) {
                 console.error("Error loading audio", error);


### PR DESCRIPTION
This commit corrects the file path for the dungeon door sound effect. The previous path was incorrect, causing all audio loading to fail. This change ensures that the ambient sound and the door sound both play correctly.