### PR TITLE
fix: Prevent character and background from disappearing

### DIFF
--- a/lumenfall/js/game.js
+++ b/lumenfall/js/game.js
@@ -464,8 +464,13 @@
             }
             joystickKnob.style.transform = `translate(-50%, -50%) translate(${deltaX}px, ${deltaY}px)`;
             const deadZone = 10;
-            joyVector.x = Math.abs(deltaX) > deadZone ? deltaX / joystickRadius : 0;
-            joyVector.y = Math.abs(deltaY) > deadZone ? -deltaY / joystickRadius : 0;
+            if (joystickRadius > 0) {
+                joyVector.x = Math.abs(deltaX) > deadZone ? deltaX / joystickRadius : 0;
+                joyVector.y = Math.abs(deltaY) > deadZone ? -deltaY / joystickRadius : 0;
+            } else {
+                joyVector.x = 0;
+                joyVector.y = 0;
+            }
         }
 
         function resetJoystick() {


### PR DESCRIPTION
This commit fixes a bug that caused the character and background to disappear during gameplay.

The issue was caused by a potential division by zero in the `moveJoystick` function, which could occur if `joystickRadius` was zero. This would result in `NaN` values being propagated to the player's and camera's positions, causing the renderer to fail.

A guard has been added to the `moveJoystick` function to check if `joystickRadius` is greater than zero before performing the division, preventing the `NaN` values and fixing the rendering issue.