### PR TITLE
feat: Adjust carousel sensitivity and desktop zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -469,7 +469,7 @@
             const isMobile = window.innerWidth < 768;
             const radius = isMobile ? 1000 : 1200;
             const cardScale = isMobile ? 0.8 : 1.0;
-            camera.position.z = isMobile ? 1400 : 1200;
+            camera.position.z = isMobile ? 1400 : 1600;
 
             carouselGroup.children.forEach((object, i) => {
                 const numElements = carouselGroup.children.length;
@@ -790,7 +790,7 @@
             }
             
             if (isDragging) {
-                const rotationFactor = 0.005; 
+                const rotationFactor = 0.002;
                 const newRotation = startRotationY + (deltaX * rotationFactor);
                 velocityY = newRotation - carouselGroup.rotation.y;
                 carouselGroup.rotation.y = newRotation;


### PR DESCRIPTION
This commit addresses two issues with the main page carousel:
1.  The touch sensitivity was too high.
2.  The camera was too close to the carousel on desktop view.

Changes:
- In `index.html`, the `rotationFactor` in the `onPointerMove` function has been decreased from `0.005` to `0.002` to make the carousel less sensitive to dragging.
- In `index.html`, the `camera.position.z` for the desktop view in the `updateLayout` function has been increased from `1200` to `1600`, effectively "zooming out" the camera to provide a better view of the carousel items.