### PR TITLE
fix(core): Correct script loading order to prevent startup crash

### DIFF
--- a/lumenfall/index.html
+++ b/lumenfall/index.html
@@ -107,12 +107,12 @@
     </div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-    <script src="js/game.js"></script>
 
     <div id="game-over-screen">
         <h1>Game Over</h1>
         <button id="continue-button">Continuar</button>
         <button id="quit-button">Salir</button>
     </div>
+    <script src="js/game.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This commit fixes a critical bug that prevented the game from starting.

The `game.js` script was being loaded before the `game-over-screen` HTML elements were parsed by the browser. This caused a `TypeError` when the script tried to get references to these non-existent elements, halting all further script execution and preventing the 'Start' button's event listener from being attached.

The fix moves the `<script>` tag to the end of the `<body>`, ensuring all DOM elements are available before the script runs.