### PR TITLE
fix(game): Corregir la animación del sprite del enemigo

### DIFF
--- a/lumenfall/js/game.js
+++ b/lumenfall/js/game.js
@@ -21,7 +21,7 @@
         const totalAttackFrames = 6;
         const totalJumpFrames = 4;
         const totalSpecterFrames = 5;
-        const totalEnemyFrames = 6;
+        const totalEnemyFrames = 4;
         const animationSpeed = 80;
         const specterAnimationSpeed = 120;
         const moveSpeed = 0.2;
@@ -1231,8 +1231,8 @@
                 this.texture = textureLoader.load(assetUrls.enemySprite);
                 this.texture.repeat.x = 1 / totalEnemyFrames;
 
-                const enemyHeight = 8.4; // Double player height + 50%
-                const enemyWidth = 8.4;
+                const enemyHeight = 4.2;
+                const enemyWidth = 4.2;
 
                 const enemyMaterial = new THREE.MeshStandardMaterial({
                     map: this.texture,


### PR DESCRIPTION
Se ajustan los parámetros de animación para el nuevo sprite del enemigo.

- Se actualiza el número total de fotogramas (`totalEnemyFrames`) de 6 a 4 para que coincida con la nueva hoja de sprites.
- Se reduce el tamaño del sprite (`enemyHeight` y `enemyWidth`) de 8.4 a 4.2 para que se muestre correctamente en el juego.

Estos cambios solucionan un problema visual en el que se mostraba toda la hoja de sprites en lugar de un único fotograma de animación.