### PR TITLE
fix(nav): Corregir enlace roto a Fórmula 1 en la página principal

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
         </a>
 
         <!-- Panel 3: Fórmula 1 -->
-        <a href="formula-1.html" class="project-card-3d">
+        <a href="formula-1/index.html" class="project-card-3d">
             <div class="glass-card rounded-lg w-full h-full">
                 <video class="card-video-bg" autoplay loop muted playsinline><source src="https://videos.pexels.com/video-files/2103949/2103949-hd_1280_720_24fps.mp4" type="video/mp4"></video>
                 <div class="card-content p-6 text-center">


### PR DESCRIPTION
Este commit soluciona un error 404 causado por la reciente refactorización de la estructura de archivos del juego de Fórmula 1.

- Se ha actualizado el enlace en el `index.html` principal para que apunte a la nueva ubicación, `formula-1/index.html`, restaurando el acceso al juego desde la página principal del portafolio.