### PR TITLE
fix: Load audio asynchronously to improve startup time

### DIFF
--- a/formula-1/js/main.js
+++ b/formula-1/js/main.js
@@ -600,7 +600,8 @@ startGameButton.addEventListener('click', async () => {
     startOverlay.style.display = 'none';
     loadingOverlay.style.display = 'flex';
 
-    await audioManager.init();
+    // Iniciar la carga de audio en segundo plano sin bloquear el inicio
+    audioManager.init();
 
     animate(); // Iniciar el bucle de renderizado inmediatamente
 


### PR DESCRIPTION
This commit changes the audio loading process to be non-blocking. The `await` keyword has been removed from the `audioManager.init()` call. This allows the game to start immediately while the audio files are downloaded in the background, addressing the issue where the game appeared to be stuck on the loading screen.