### PR TITLE
fix: Rework touch UI with CSS and add gamepad indicator

### DIFF
--- a/formula-1/css/style.css
+++ b/formula-1/css/style.css
@@ -37,32 +37,103 @@ canvas {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
 }
-.touch-controls {
+/* --- Estilos de Controles Táctiles --- */
+.touch-controls-container {
     position: absolute;
-    bottom: 20px;
-    left: 50%;
-    transform: translateX(-50%);
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 30%;
     display: flex;
     justify-content: space-between;
-    width: 220px;
+    align-items: flex-end;
+    padding: 20px;
+    box-sizing: border-box;
     pointer-events: none;
     z-index: 10;
+    display: none; /* Hidden by default, shown by JS */
 }
-.d-pad {
-    display: grid;
+
+/* Joystick a la izquierda */
+.joystick {
+    width: 150px;
+    height: 150px;
+    position: relative;
+    pointer-events: auto;
+}
+.joystick-base {
+    width: 100%;
+    height: 100%;
+    background-color: rgba(255, 255, 255, 0.2);
+    border-radius: 50%;
+}
+.joystick-stick {
+    position: absolute;
+    top: 37.5px;
+    left: 37.5px;
+    width: 75px;
+    height: 75px;
+    background-color: rgba(255, 255, 255, 0.5);
+    border-radius: 50%;
+    transition: transform 0.1s ease-out;
+}
+
+/* Cluster de botones a la derecha */
+.actions-cluster {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
     gap: 10px;
     pointer-events: auto;
-    grid-template-areas:
-        ". up ."
-        "left . right"
-        ". down .";
-    grid-template-columns: 60px 60px 60px;
-    grid-template-rows: 60px 60px;
 }
-#touch-up { grid-area: up; }
-#touch-down { grid-area: down; }
-#touch-left { grid-area: left; }
-#touch-right { grid-area: right; }
+.gear-buttons {
+    display: flex;
+    gap: 10px;
+}
+.main-pedals {
+    display: flex;
+    gap: 10px;
+    align-items: flex-end;
+}
+.touch-button {
+    font-size: 18px;
+    font-weight: bold;
+    color: white;
+    background-color: rgba(0,0,0,0.4);
+    border: 2px solid rgba(255,255,255,0.2);
+    border-radius: 15px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    user-select: none;
+}
+.touch-button:active {
+    background-color: rgba(74, 222, 128, 0.5);
+}
+.gear-button {
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+}
+.brake-button {
+    width: 100px;
+    height: 70px;
+}
+.accelerate-button {
+    width: 120px;
+    height: 90px;
+}
+
+/* Indicador de Gamepad */
+.gamepad-indicator {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    font-size: 32px;
+    opacity: 0.3;
+    transition: opacity 0.5s ease;
+    z-index: 11;
+}
 .ui-button {
     background: rgba(26, 32, 44, 0.6);
     backdrop-filter: blur(10px);

--- a/formula-1/index.html
+++ b/formula-1/index.html
@@ -20,19 +20,26 @@
         <p>Generando Bosque Mixto...</p>
     </div>
 
-    <div class="touch-controls" style="display: none;">
+    <div class="touch-controls-container">
         <!-- Joystick a la izquierda -->
-        <div id="joystick-container" style="position: absolute; bottom: 40px; left: 40px; width: 150px; height: 150px;">
-            <div id="joystick-base" style="position: absolute; width: 100%; height: 100%; background-color: rgba(255,255,255,0.2); border-radius: 50%;"></div>
-            <div id="joystick-stick" style="position: absolute; top: 37.5px; left: 37.5px; width: 75px; height: 75px; background-color: rgba(255,255,255,0.5); border-radius: 50%;"></div>
+        <div id="joystick-container" class="joystick">
+            <div id="joystick-base" class="joystick-base"></div>
+            <div id="joystick-stick" class="joystick-stick"></div>
         </div>
 
         <!-- Controles a la derecha -->
-        <div id="touch-brake" class="touch-button" style="position: absolute; bottom: 20px; right: 180px; width: 120px; height: 80px; background-color: rgba(255,0,0,0.5); border-radius: 10px; display: flex; justify-content: center; align-items: center;">FRENO</div>
-        <div id="touch-accelerate" class="touch-button" style="position: absolute; bottom: 20px; right: 20px; width: 150px; height: 100px; background-color: rgba(0,255,0,0.5); border-radius: 10px; display: flex; justify-content: center; align-items: center;">ACELERAR</div>
-        <div id="touch-gear-up" class="touch-button" style="position: absolute; bottom: 130px; right: 20px; width: 60px; height: 60px; background-color: rgba(255,255,255,0.5); border-radius: 50%; display: flex; justify-content: center; align-items: center;">▲</div>
-        <div id="touch-gear-down" class="touch-button" style="position: absolute; bottom: 130px; right: 90px; width: 60px; height: 60px; background-color: rgba(255,255,255,0.5); border-radius: 50%; display: flex; justify-content: center; align-items: center;">▼</div>
+        <div class="actions-cluster">
+            <div class="gear-buttons">
+                <div id="touch-gear-up" class="touch-button gear-button">▲</div>
+                <div id="touch-gear-down" class="touch-button gear-button">▼</div>
+            </div>
+            <div class="main-pedals">
+                <div id="touch-brake" class="touch-button brake-button">FRENO</div>
+                <div id="touch-accelerate" class="touch-button accelerate-button">ACELERAR</div>
+            </div>
+        </div>
     </div>
+    <div id="gamepad-status" class="gamepad-indicator">🎮</div>
     <div id="camera-button" class="ui-button">📷</div>
 
     <div id="countdown-overlay" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: none; justify-content: center; align-items: center; z-index: 99; font-size: 15vw; color: white; font-weight: bold; text-shadow: 0 0 20px black;"></div>

--- a/formula-1/js/main.js
+++ b/formula-1/js/main.js
@@ -504,8 +504,12 @@ function startCountdown() {
 }
 
 function handleGamepad() {
+    const gamepadStatus = document.getElementById('gamepad-status');
     const gamepads = navigator.getGamepads();
+
     if (gamepads[0]) {
+        if (gamepadStatus) gamepadStatus.style.opacity = '1';
+
         const gamepad = gamepads[0];
         controls.throttle = gamepad.buttons[7].value;
         controls.brake = gamepad.buttons[6].value;
@@ -523,6 +527,8 @@ function handleGamepad() {
         } else {
             controls.gearDown = false;
         }
+    } else {
+        if (gamepadStatus) gamepadStatus.style.opacity = '0.3';
     }
 }
 
@@ -630,12 +636,16 @@ function animate() {
 const startOverlay = document.getElementById('start-overlay');
 const startGameButton = document.getElementById('start-game-button');
 const loadingOverlay = document.getElementById('loading-overlay');
-const touchControls = document.querySelector('.touch-controls');
+const touchControls = document.querySelector('.touch-controls-container');
 
 startGameButton.addEventListener('click', async () => {
     startOverlay.style.display = 'none';
     loadingOverlay.style.display = 'none'; // Ocultar inmediatamente
-    touchControls.style.display = 'flex';
+
+    // Show touch controls only on touch devices
+    if ('ontouchstart' in window || navigator.maxTouchPoints > 0) {
+        touchControls.style.display = 'flex';
+    }
 
     // Iniciar la carga de audio en segundo plano
     audioManager.init();


### PR DESCRIPTION
This commit addresses user feedback regarding the touch control layout and gamepad connection status.

Key changes:
- Reworked the touch control UI by removing all inline styles and moving them to a dedicated CSS file (`formula-1/css/style.css`). This uses a Flexbox layout to ensure the joystick on the left and the action buttons on the right do not overlap, regardless of screen size.
- Added a visual gamepad indicator icon (🎮) to the UI. This icon lights up when a gamepad is detected by the browser's Gamepad API, providing clear, immediate feedback to the user that their controller is connected and working.
- This provides a more robust, professional, and user-friendly experience.