### PR TITLE
Fix: Corrige el fallo de los controles debido a un ReferenceError

### DIFF
--- a/formula-1/js/main.js
+++ b/formula-1/js/main.js
@@ -231,12 +231,13 @@ scene.add(car);
 // --- FÍSICA DEL VEHÍCULO ---
 let carSpeed = 0; // en m/s
 let engineRPM = 0;
-let currentGear = 0;
+let currentGear = 1; // Empezar en Neutral en lugar de Reversa
 let trackProgress = 0.001;
 let lateralOffset = 0;
 
 const MAX_LATERAL_OFFSET = ASPHALT_WIDTH / 2 - 1.2;
 const STEER_SENSITIVITY = 2.5; // A mayor valor, más sensible
+const MAX_SPEED = 90; // m/s, approx 324 km/h
 const DRAG_COEFFICIENT = 0.4257;
 const ROLLING_RESISTANCE = 30.0;
 const BRAKE_FORCE = 8000.0;


### PR DESCRIPTION
Define la constante `MAX_SPEED` que faltaba en `main.js` para evitar un error fatal durante la inicialización de la carrera. Este error impedía que el estado del juego se actualizara correctamente, lo que hacía que los controles no funcionaran.

Chore: Cambia la marcha inicial a Neutral para una mejor experiencia de usuario.