### PR TITLE
Fix: Inicializa el motor con RPM en ralentí para permitir el movimiento

### DIFF
--- a/formula-1/js/main.js
+++ b/formula-1/js/main.js
@@ -227,8 +227,8 @@ scene.add(car);
 
 // --- FÍSICA DEL VEHÍCULO ---
 let carSpeed = 0; // en m/s
-let engineRPM = 0;
-let currentGear = 2; // Empezar en Primera Marcha
+let engineRPM = 800; // Empezar con el motor en ralentí (IDLE_RPM)
+let currentGear = 1; // Empezar en Neutral
 let trackProgress = 0.001;
 let lateralOffset = 0;
 


### PR DESCRIPTION
Cambia el valor inicial de `engineRPM` de 0 a 800 (IDLE_RPM). Esto soluciona un error fundamental en la física por el que el motor no podía generar torque desde un estado de reposo, impidiendo que el coche se moviera.

Reajusta la marcha inicial a Neutral (1) para un inicio más realista.