### PR TITLE
feat: add joystick and button touch controls

### DIFF
--- a/formula-1/index.html
+++ b/formula-1/index.html
@@ -44,32 +44,27 @@
             0% { transform: rotate(0deg); }
             100% { transform: rotate(360deg); }
         }
-        .touch-controls {
+        #joystick-zone {
             position: absolute;
-            bottom: 20px;
-            left: 50%;
-            transform: translateX(-50%);
+            left: 12vw;
+            bottom: 15vh;
+            width: 150px;
+            height: 150px;
+            background: rgba(0,0,0,0.1);
+            border-radius: 50%;
+        }
+        #touch-buttons-right {
+            position: absolute;
+            right: 12vw;
+            bottom: 15vh;
             display: flex;
-            justify-content: space-between;
-            width: 220px;
-            pointer-events: none;
-            z-index: 10;
+            flex-direction: column;
+            align-items: center;
         }
-        .d-pad {
-            display: grid;
-            gap: 10px;
-            pointer-events: auto;
-            grid-template-areas:
-                ". up ."
-                "left . right"
-                ". down .";
-            grid-template-columns: 60px 60px 60px;
-            grid-template-rows: 60px 60px;
+        #engine-button {
+            top: 20px;
+            left: 20px;
         }
-        #touch-up { grid-area: up; }
-        #touch-down { grid-area: down; }
-        #touch-left { grid-area: left; }
-        #touch-right { grid-area: right; }
         .ui-button {
             background: rgba(26, 32, 44, 0.6);
             backdrop-filter: blur(10px);
@@ -113,6 +108,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@500;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/nipplejs/dist/nipplejs.min.js"></script>
 </head>
 <body>
     <div id="loading-overlay">
@@ -120,14 +116,14 @@
         <p>Generando Bosque Mixto...</p>
     </div>
 
-    <div class="touch-controls">
-        <div class="d-pad">
-            <div id="touch-up" class="ui-button touch-button">▲</div>
-            <div id="touch-left" class="ui-button touch-button">◀</div>
-            <div id="touch-right" class="ui-button touch-button">▶</div>
-            <div id="touch-down" class="ui-button touch-button">▼</div>
-        </div>
+    <div id="joystick-zone" style="position: absolute; left: 15vw; bottom: 20vh; width: 150px; height: 150px;"></div>
+
+    <div id="touch-buttons-right" style="position: absolute; right: 15vw; bottom: 20vh; display: flex; flex-direction: column; align-items: center;">
+        <div id="touch-accelerate" class="ui-button touch-button" style="margin-bottom: 20px;">A</div>
+        <div id="touch-brake" class="ui-button touch-button">B</div>
     </div>
+
+    <div id="engine-button" class="ui-button" style="top: 20px; left: 20px; width: 60px; height: 60px; border-radius: 50%; font-size: 24px;">⚡</div>
     <div id="camera-button" class="ui-button">📷</div>
 
     <script type="importmap">


### PR DESCRIPTION
This commit replaces the D-pad with a virtual joystick for steering and adds dedicated buttons for acceleration and braking, providing a more modern and user-friendly touch interface.

- Integrates the `nipplejs` library for the virtual joystick.
- Updates the HTML to remove the old D-pad and add the new control elements (joystick zone, A/B buttons, engine toggle button).
- Adds CSS to style and position the new controls.
- Implements the JavaScript logic in `main.js` to handle input from the joystick and touch buttons.
- The `animate` loop is updated to combine and prioritize touch controls over keyboard inputs, allowing both to be used.