### PR TITLE
fix: enable multitouch for joystick controls

### DIFF
--- a/formula-1/js/main.js
+++ b/formula-1/js/main.js
@@ -218,7 +218,8 @@ const joystick = nipplejs.create({
     mode: 'static',
     position: { left: '50%', top: '50%' },
     color: 'white',
-    size: 120
+    size: 120,
+    multitouch: true
 }).on('move', (evt, data) => {
     if (data.angle && data.force > 0.3) {
         if (data.angle.degree > 45 && data.angle.degree < 135) {


### PR DESCRIPTION
The joystick was capturing all touch events, which prevented the user from steering and accelerating at the same time.

This commit enables the `multitouch: true` option in the `nipplejs` configuration, allowing the button event listeners to fire even when a touch is active on the joystick. This resolves the issue of the accelerator and brake buttons being unresponsive.