### PR TITLE
build: swap A/B buttons for diagnostic test

### DIFF
--- a/formula-1/js/main.js
+++ b/formula-1/js/main.js
@@ -255,13 +255,14 @@ const setBrake = (state) => {
     brakeButton.classList.toggle('active', state);
 };
 
-accelButton.addEventListener('touchstart', (e) => { e.preventDefault(); setAccelerate(true); }, { passive: false });
-accelButton.addEventListener('touchend', (e) => { e.preventDefault(); setAccelerate(false); });
-accelButton.addEventListener('touchcancel', (e) => { e.preventDefault(); setAccelerate(false); });
+// PRUEBA: Intercambiar botones
+accelButton.addEventListener('touchstart', (e) => { e.preventDefault(); setBrake(true); }, { passive: false });
+accelButton.addEventListener('touchend', (e) => { e.preventDefault(); setBrake(false); });
+accelButton.addEventListener('touchcancel', (e) => { e.preventDefault(); setBrake(false); });
 
-brakeButton.addEventListener('touchstart', (e) => { e.preventDefault(); setBrake(true); }, { passive: false });
-brakeButton.addEventListener('touchend', (e) => { e.preventDefault(); setBrake(false); });
-brakeButton.addEventListener('touchcancel', (e) => { e.preventDefault(); setBrake(false); });
+brakeButton.addEventListener('touchstart', (e) => { e.preventDefault(); setAccelerate(true); }, { passive: false });
+brakeButton.addEventListener('touchend', (e) => { e.preventDefault(); setAccelerate(false); });
+brakeButton.addEventListener('touchcancel', (e) => { e.preventDefault(); setAccelerate(false); });
 
 // --- Engine Button with Hold ---
 engineButton.addEventListener('touchstart', (e) => {


### PR DESCRIPTION
This commit temporarily swaps the event listeners for the accelerate and brake buttons to diagnose a bug. The 'A' button now brakes, and the 'B' button now accelerates. This is intended to be reverted after testing.