### PR TITLE
build: add diagnostic button 'C'

### DIFF
--- a/formula-1/index.html
+++ b/formula-1/index.html
@@ -120,7 +120,8 @@
 
     <div id="touch-buttons-right" style="position: absolute; right: 15vw; bottom: 20vh; display: flex; flex-direction: column; align-items: center;">
         <div id="touch-accelerate" class="ui-button touch-button" style="margin-bottom: 20px;">A</div>
-        <div id="touch-brake" class="ui-button touch-button">B</div>
+        <div id="touch-brake" class="ui-button touch-button" style="margin-bottom: 20px;">B</div>
+        <div id="touch-accelerate-c" class="ui-button touch-button">C</div>
     </div>
 
     <div id="engine-button" class="ui-button" style="top: 20px; left: 20px; width: 60px; height: 60px; border-radius: 50%; font-size: 24px;">⚡</div>

--- a/formula-1/js/main.js
+++ b/formula-1/js/main.js
@@ -243,6 +243,7 @@ const joystick = nipplejs.create({
 const accelButton = document.getElementById('touch-accelerate');
 const brakeButton = document.getElementById('touch-brake');
 const engineButton = document.getElementById('engine-button');
+const accelButtonC = document.getElementById('touch-accelerate-c'); // Botón de prueba C
 let engineToggleTimeout;
 
 const setAccelerate = (state) => {
@@ -255,14 +256,17 @@ const setBrake = (state) => {
     brakeButton.classList.toggle('active', state);
 };
 
-// PRUEBA: Intercambiar botones
-accelButton.addEventListener('touchstart', (e) => { e.preventDefault(); setBrake(true); }, { passive: false });
-accelButton.addEventListener('touchend', (e) => { e.preventDefault(); setBrake(false); });
-accelButton.addEventListener('touchcancel', (e) => { e.preventDefault(); setBrake(false); });
+accelButton.addEventListener('touchstart', (e) => { e.preventDefault(); setAccelerate(true); }, { passive: false });
+accelButton.addEventListener('touchend', (e) => { e.preventDefault(); setAccelerate(false); });
+accelButton.addEventListener('touchcancel', (e) => { e.preventDefault(); setAccelerate(false); });
 
-brakeButton.addEventListener('touchstart', (e) => { e.preventDefault(); setAccelerate(true); }, { passive: false });
-brakeButton.addEventListener('touchend', (e) => { e.preventDefault(); setAccelerate(false); });
-brakeButton.addEventListener('touchcancel', (e) => { e.preventDefault(); setAccelerate(false); });
+brakeButton.addEventListener('touchstart', (e) => { e.preventDefault(); setBrake(true); }, { passive: false });
+brakeButton.addEventListener('touchend', (e) => { e.preventDefault(); setBrake(false); });
+brakeButton.addEventListener('touchcancel', (e) => { e.preventDefault(); setBrake(false); });
+
+accelButtonC.addEventListener('touchstart', (e) => { e.preventDefault(); setAccelerate(true); }, { passive: false });
+accelButtonC.addEventListener('touchend', (e) => { e.preventDefault(); setAccelerate(false); });
+accelButtonC.addEventListener('touchcancel', (e) => { e.preventDefault(); setAccelerate(false); });
 
 // --- Engine Button with Hold ---
 engineButton.addEventListener('touchstart', (e) => {


### PR DESCRIPTION
This commit adds a new button 'C' to the UI and wires it to the same acceleration logic as button 'A'. This is to test a bug where the 'A' button is unresponsive. The original functionality of 'A' and 'B' has been restored.