### PR TITLE
fix(lumenfall): Hacer que la cámara de juego sea estática

### DIFF
--- a/lumenfall/js/game.js
+++ b/lumenfall/js/game.js
@@ -947,7 +947,6 @@
 
                 this.mesh.position.x = Math.max(this.minPlayerX, Math.min(this.maxPlayerX, this.mesh.position.x));
                 this.mesh.rotation.y = this.isFacingLeft ? Math.PI : 0;
-                camera.position.x = this.mesh.position.x;
                 this.playerLight.position.set(this.mesh.position.x, this.mesh.position.y + 1, this.mesh.position.z + 2);
 
                 if (this.currentState !== previousState) this.currentFrame = 0;


### PR DESCRIPTION
Se elimina la línea de código que actualizaba la posición horizontal de la cámara para que coincidiera con la del jugador.

Esto responde a la petición del usuario de que la cámara permanezca fija y no 'jale' la pantalla cuando el personaje se mueve, resultando en una vista estática del nivel.