### PR TITLE
Fix UI visibility and touch gesture conflicts.

### DIFF
--- a/lumenfall/css/style.css
+++ b/lumenfall/css/style.css
@@ -4,6 +4,7 @@
             overflow: hidden;
             background-color: #000;
             font-family: 'Inter', sans-serif;
+            touch-action: none;
         }
 
         /* Canvas de fondo para Three.js */

--- a/lumenfall/js/game.js
+++ b/lumenfall/js/game.js
@@ -384,6 +384,8 @@
                 menuScreen.style.display = 'none';
                 document.getElementById('bg-canvas').style.display = 'block';
                 document.getElementById('ui-container').style.display = 'flex';
+                controlsContainer.style.opacity = '1';
+                controlsContainer.style.pointerEvents = 'auto';
                 player = new Player();
                 loadLevelById(currentLevelId);
                 animate();


### PR DESCRIPTION
- Ensures on-screen UI controls (joystick, buttons) are visible when the game starts.
- Prevents the browser's native 'swipe-to-navigate' gesture from being triggered by the on-screen joystick, which caused the screen to appear to shrink. This is fixed by adding `touch-action: none` to the body style.