### PR TITLE
feat: Update og:image URL for social media preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <!-- Open Graph / Metaetiquetas para Redes Sociales -->
     <meta property="og:title" content="JUSN38 STUDY: Juegos y Herramientas Creativas" />
     <meta property="og:description" content="¡El aburrimiento no existe aquí! 🎮 Descubre una colección de juegos adictivos y herramientas útiles. ¿Listo para el desafío? ¡Entra y juega!" />
-    <meta property="og:image" content="https://raw.githubusercontent.com/Yanzsmartwood2025/JUSN38/e02e4d6b9e8bb484e9bebd211e55cfdfe67eea7f/assets/images/JUSN38/social-preview.png" />
+    <meta property="og:image" content="https://jusn-38.vercel.app/assets/images/JUSN38/social-preview.png" />
     <meta property="og:url" content="https://jusn-38.vercel.app" />
     <meta property="og:type" content="website" />
 


### PR DESCRIPTION
Updates the `og:image` meta tag in `index.html` to use an absolute URL from the Vercel deployment instead of a raw GitHub content URL. This ensures better compatibility with social media crawlers.