### PR TITLE
fix: Update og:image to 512x512 icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <!-- Open Graph / Metaetiquetas para Redes Sociales -->
     <meta property="og:title" content="JUSN38 STUDY: Juegos y Herramientas Creativas" />
     <meta property="og:description" content="¡El aburrimiento no existe aquí! 🎮 Descubre una colección de juegos adictivos y herramientas útiles. ¿Listo para el desafío? ¡Entra y juega!" />
-    <meta property="og:image" content="https://jusn-38.vercel.app/assets/images/JUSN38/social-preview.png" />
+    <meta property="og:image" content="https://jusn-38.vercel.app/assets/images/JUSN38/Jusn38-icon-512x512.png" />
     <meta property="og:url" content="https://jusn-38.vercel.app" />
     <meta property="og:type" content="website" />
 


### PR DESCRIPTION
Updates the `og:image` meta tag in `index.html` to use the `Jusn38-icon-512x512.png` image as requested by the user to troubleshoot social media preview issues.