### PR TITLE
feat: Rediseñar controles y corregir bug de carga

### DIFF
--- a/estudio_de_sonido/css/main.css
+++ b/estudio_de_sonido/css/main.css
@@ -173,6 +173,34 @@ input[type="range"].w-full::-webkit-slider-thumb {
     box-shadow: 0 0 15px 5px rgba(156, 163, 175, 0.7), inset 0 0 10px rgba(156, 163, 175, 0.5);
 }
 
+/* Button Glow Effects */
+@keyframes pulse-glow {
+    0% { box-shadow: 0 0 0 0 var(--glow-color-start); }
+    70% { box-shadow: 0 0 10px 10px var(--glow-color-end); }
+    100% { box-shadow: 0 0 0 0 var(--glow-color-start); }
+}
+
+.glow-red {
+    --glow-color-start: rgba(239, 68, 68, 0.7);
+    --glow-color-end: rgba(239, 68, 68, 0);
+    animation: pulse-glow 1.5s infinite;
+    background-color: #ef4444; /* red-500 */
+}
+
+.glow-white {
+    --glow-color-start: rgba(255, 255, 255, 0.7);
+    --glow-color-end: rgba(255, 255, 255, 0);
+    animation: pulse-glow 1.5s infinite;
+    box-shadow: 0 0 8px 2px #fff;
+}
+
+.glow-blue {
+    --glow-color-start: rgba(59, 130, 246, 0.7);
+    --glow-color-end: rgba(59, 130, 246, 0);
+    animation: pulse-glow 1.5s infinite;
+    background-color: #3b82f6; /* blue-500 */
+}
+
 input[type="range"].w-full::-moz-range-thumb {
     width: 16px;
     height: 16px;

--- a/estudio_de_sonido/index.html
+++ b/estudio_de_sonido/index.html
@@ -18,7 +18,6 @@
             <h2 class="text-xl font-bold text-white pl-2">Jusn38 Studio</h2>
             <input type="file" id="audio-upload" class="hidden" accept="audio/*">
             <button id="open-file-btn" class="menu-btn px-3 py-1 rounded-md text-sm"><i class="fas fa-folder-open mr-2"></i>Abrir</button>
-            <button id="record-btn" class="menu-btn px-3 py-1 rounded-md text-sm"><i class="fas fa-microphone mr-2"></i>Grabar</button>
             <button id="save-file-btn" class="menu-btn px-3 py-1 rounded-md text-sm"><i class="fas fa-save mr-2"></i>Guardar</button>
             <span id="recording-indicator" class="hidden text-sm text-red-400 font-bold">Grabando...</span>
         </div>
@@ -43,22 +42,31 @@
                         <p>Abre un archivo o graba para comenzar</p>
                     </div>
                 </div>
-                <div id="player-controls" class="hidden flex items-center gap-4 p-2 bg-black/30 rounded-lg">
-                     <div class="flex items-center gap-2 text-gray-400 text-sm w-24"><span id="current-time">0:00</span> / <span id="total-time">0:00</span></div>
-                    <div class="flex-grow flex items-center justify-center gap-4">
-                        <button id="restart-button" title="Reiniciar" class="w-10 h-10 text-lg text-white rounded-full hover:bg-white/10 transition"><i class="fas fa-undo"></i></button>
-                        <button id="play-pause-button" title="Reproducir/Pausar" class="w-14 h-14 text-2xl text-black bg-white rounded-full hover:scale-105 transition flex-shrink-0"><i class="fas fa-play"></i></button>
-                        <button id="loop-button" title="Repetir" class="w-10 h-10 text-lg text-white rounded-full hover:bg-white/10 transition"><i class="fas fa-retweet"></i></button>
+                <div id="dj-disk-container" class="bg-black/30 rounded-lg p-4 relative flex flex-col justify-center items-center">
+                    <div id="dj-disk" class="relative">
+                        <div id="disk-handle"></div>
+                        <!-- New controls positioned on the disk -->
+                        <div id="disk-controls" class="absolute inset-0 flex flex-col justify-center items-center gap-2 z-10">
+                            <button id="record-btn" title="Grabar" class="w-10 h-10 text-lg text-white bg-red-800 rounded-full hover:bg-red-700 transition"><i class="fas fa-microphone"></i></button>
+                            <div class="flex items-center justify-center gap-4">
+                                 <button id="restart-button" title="Reiniciar" class="w-10 h-10 text-lg text-white rounded-full hover:bg-white/10 transition"><i class="fas fa-undo"></i></button>
+                                 <button id="play-pause-button" title="Reproducir/Pausar" class="w-14 h-14 text-2xl text-black bg-white rounded-full hover:scale-105 transition flex-shrink-0"><i class="fas fa-play"></i></button>
+                                 <button id="loop-button" title="Repetir" class="w-10 h-10 text-lg text-white rounded-full hover:bg-white/10 transition"><i class="fas fa-retweet"></i></button>
+                            </div>
+                        </div>
                     </div>
-                    <div class="flex items-center gap-2 w-24"></div>
-                </div>
-                <div id="dj-disk-container" class="bg-black/30 rounded-lg p-4">
-                    <div id="dj-disk"><div id="disk-handle"></div></div>
-                    <p class="text-xs text-gray-500 text-center mt-2">Control de Filtro (↕) y Distorsión (↔)</p>
-                    <div class="flex justify-center items-center gap-2 mt-3">
-                        <button data-color="blue" class="color-switcher w-6 h-6 rounded-full bg-blue-500 border-2 border-gray-700 hover:border-white"></button>
-                        <button data-color="white" class="color-switcher w-6 h-6 rounded-full bg-white border-2 border-gray-700 hover:border-white"></button>
-                        <button data-color="gray" class="color-switcher w-6 h-6 rounded-full bg-gray-500 border-2 border-gray-700 hover:border-white"></button>
+
+                    <div class="w-full mt-2">
+                        <p class="text-xs text-gray-500 text-center mt-2">Control de Filtro (↕) y Distorsión (↔)</p>
+                        <div class="flex items-center justify-between gap-2 text-gray-400 text-sm w-full mt-1 px-4">
+                            <span id="current-time" class="w-12 text-left">0:00</span>
+                            <div class="flex justify-center items-center gap-2">
+                                <button data-color="blue" class="color-switcher w-6 h-6 rounded-full bg-blue-500 border-2 border-gray-700 hover:border-white"></button>
+                                <button data-color="white" class="color-switcher w-6 h-6 rounded-full bg-white border-2 border-gray-700 hover:border-white"></button>
+                                <button data-color="gray" class="color-switcher w-6 h-6 rounded-full bg-gray-500 border-2 border-gray-700 hover:border-white"></button>
+                            </div>
+                            <span id="total-time" class="w-12 text-right">0:00</span>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Reestructura la interfaz de usuario para mover los controles de reproducción (Play, Grabar, Repetir) sobre el disco de DJ, eliminando la barra de control anterior.

- Soluciona un error crítico que impedía que los archivos de audio cargados se reprodujeran correctamente.
- Añade efectos de brillo a los botones de control para indicar su estado (grabando, reproduciendo, etc.).
- Elimina el botón de grabar de la barra de menú superior.
- Prepara la base para las mejoras visuales de la Fase 2.