### PR TITLE
The DJ disk skin images were not displaying because the CSS was using…

### DIFF
--- a/estudio_de_sonido/css/main.css
+++ b/estudio_de_sonido/css/main.css
@@ -150,10 +150,10 @@ input[type="range"].w-full::-webkit-slider-thumb {
 }
 
 /* Disk Skin Images */
-#dj-disk.disk-skin-1 { background-image: url('https://raw.githubusercontent.com/Yanzsmartwood2025/JUSN38/main/JUSN38/estudio_de_sonido/assets/imagenes/IMAGENES/disco-1.png'); }
-#dj-disk.disk-skin-2 { background-image: url('https://raw.githubusercontent.com/Yanzsmartwood2025/JUSN38/main/JUSN38/estudio_de_sonido/assets/imagenes/IMAGENES/disco-2.png'); }
-#dj-disk.disk-skin-3 { background-image: url('https://raw.githubusercontent.com/Yanzsmartwood2025/JUSN38/main/JUSN38/estudio_de_sonido/assets/imagenes/IMAGENES/disco-3.png'); }
-#dj-disk.disk-skin-4 { background-image: url('https://raw.githubusercontent.com/Yanzsmartwood2025/JUSN38/main/JUSN38/estudio_de_sonido/assets/imagenes/IMAGENES/disco-4.png'); }
+#dj-disk.disk-skin-1 { background-image: url('../assets/imagenes/disco-1.png'); }
+#dj-disk.disk-skin-2 { background-image: url('../assets/imagenes/disco-2.png'); }
+#dj-disk.disk-skin-3 { background-image: url('../assets/imagenes/disco-3.png'); }
+#dj-disk.disk-skin-4 { background-image: url('../assets/imagenes/disco-4.png'); }
 
 #dj-disk[class*="disk-skin-"] {
     background-size: cover;


### PR DESCRIPTION
> … absolute GitHub URLs instead of local relative paths.

This commit updates the `background-image` URLs in `estudio_de_sonido/css/main.css` to use the correct relative paths to the image assets. This allows the browser to load the images correctly.

The existing `background-size: cover` and `background-position: center` properties will ensure the images are centered as requested.