### PR TITLE
This commit adjusts the main grid layout to be non-responsive, based …

### DIFF
--- a/estudio_de_sonido/index.html
+++ b/estudio_de_sonido/index.html
@@ -26,7 +26,7 @@
         <div class="flex-grow p-4 grid grid-cols-12 gap-4 overflow-hidden">
 
             <!-- MAIN HORIZONTAL LAYOUT PANEL -->
-            <div id="center-panel" class="col-span-12 md:col-span-9 bg-black/20 rounded-lg flex flex-col gap-4 p-4">
+            <div id="center-panel" class="col-span-9 bg-black/20 rounded-lg flex flex-col gap-4 p-4">
 
                 <!-- TOP SECTION (30%) -->
                 <div class="h-[30%] flex flex-col gap-4">
@@ -94,7 +94,7 @@
             </div>
 
             <!-- RIGHT PANEL: MIXER -->
-            <div id="mixer-panel" class="col-span-12 md:col-span-3 bg-black/20 rounded-lg p-4 overflow-y-auto">
+            <div id="mixer-panel" class="col-span-3 bg-black/20 rounded-lg p-4 overflow-y-auto">
                  <h3 class="font-bold text-center mb-4">Mesa de Mezclas</h3>
                  <!-- FX CONTROLS WILL BE ADDED HERE -->
                  <div id="fx-controls-container" class="space-y-4">


### PR DESCRIPTION
…on user feedback.

The `md:` prefixes have been removed from the grid column classes in `index.html`. This forces the two-column layout (main panel and mixer) to persist on all screen sizes, preventing the UI from stacking vertically on smaller viewports.