### PR TITLE
fix(estudio-sonido): Correct layout and overflow issues

### DIFF
--- a/estudio_de_sonido/index.html
+++ b/estudio_de_sonido/index.html
@@ -33,129 +33,19 @@
         <!-- MAIN CONTENT GRID -->
         <div class="flex-grow p-4 grid grid-cols-12 gap-4 overflow-hidden">
 
-            <!-- LEFT PANEL: MIXER -->
-            <div id="mixer-panel" class="col-span-3 bg-black/20 rounded-lg p-4 overflow-y-auto">
-                <h3 class="font-bold text-center mb-4">Mesa de Mezclas</h3>
-                <!-- FX CONTROLS WILL BE ADDED HERE -->
-                <div id="fx-controls-container" class="space-y-4">
-                   <!-- Dinámica -->
-                   <div>
-                       <h4 class="font-bold text-sm text-gray-400 mb-2 border-b border-gray-700 pb-1">Dinámica</h4>
-                       <div class="space-y-3 text-xs p-2">
-                           <div class="control-group">
-                               <label for="compressor-threshold">Compresor: Umbral <span id="compressor-threshold-value">-24</span> dB</label>
-                               <input type="range" id="compressor-threshold" min="-100" max="0" value="-24" step="1" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
-                           </div>
-                           <div class="control-group">
-                               <label for="compressor-ratio">Compresor: Ratio <span id="compressor-ratio-value">12</span>:1</label>
-                               <input type="range" id="compressor-ratio" min="1" max="20" value="12" step="1" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
-                           </div>
-                           <div class="control-group">
-                               <label for="compressor-attack">Compresor: Ataque <span id="compressor-attack-value">0.003</span>s</label>
-                               <input type="range" id="compressor-attack" min="0.001" max="1" value="0.003" step="0.001" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
-                           </div>
-                            <div class="control-group">
-                               <label for="compressor-release">Compresor: Relajación <span id="compressor-release-value">0.25</span>s</label>
-                               <input type="range" id="compressor-release" min="0.01" max="1" value="0.25" step="0.01" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
-                           </div>
-                           <div class="control-group">
-                               <label for="gate-threshold">Puerta de Ruido: Umbral <span id="gate-threshold-value">-40</span> dB</label>
-                               <input type="range" id="gate-threshold" min="-100" max="0" value="-40" step="1" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
-                           </div>
-                       </div>
-                   </div>
-                   <!-- Ecualizador -->
-                   <div>
-                       <h4 class="font-bold text-sm text-gray-400 mb-2 border-b border-gray-700 pb-1">Ecualizador (3-Band)</h4>
-                        <div class="space-y-3 text-xs p-2">
-                           <div class="control-group">
-                               <label for="eq-low">Graves <span id="eq-low-value">0</span> dB</label>
-                               <input type="range" id="eq-low" min="-24" max="12" value="0" step="1" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
-                           </div>
-                           <div class="control-group">
-                               <label for="eq-mid">Medios <span id="eq-mid-value">0</span> dB</label>
-                               <input type="range" id="eq-mid" min="-24" max="12" value="0" step="1" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
-                           </div>
-                           <div class="control-group">
-                               <label for="eq-high">Agudos <span id="eq-high-value">0</span> dB</label>
-                               <input type="range" id="eq-high" min="-24" max="12" value="0" step="1" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
-                           </div>
-                       </div>
-                   </div>
-                   <!-- Tiempo y Espacio -->
-                   <div>
-                       <h4 class="font-bold text-sm text-gray-400 mb-2 border-b border-gray-700 pb-1">Tiempo y Espacio</h4>
-                        <div class="space-y-3 text-xs p-2">
-                           <div class="control-group">
-                               <label for="reverb-decay">Reverb: Duración <span id="reverb-decay-value">1.5</span>s</label>
-                               <input type="range" id="reverb-decay" min="0.1" max="10" value="1.5" step="0.1" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
-                           </div>
-                           <div class="control-group">
-                               <label for="reverb-wet">Reverb: Mezcla <span id="reverb-wet-value">0</span></label>
-                               <input type="range" id="reverb-wet" min="0" max="1" value="0" step="0.01" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
-                           </div>
-                           <div class="control-group">
-                               <label for="delay-time">Delay: Tiempo <span id="delay-time-value">0.5</span>s</label>
-                               <input type="range" id="delay-time" min="0" max="1" value="0.5" step="0.01" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
-                           </div>
-                           <div class="control-group">
-                               <label for="delay-feedback">Delay: Repeticiones <span id="delay-feedback-value">0.5</span></label>
-                               <input type="range" id="delay-feedback" min="0" max="0.9" value="0.5" step="0.01" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
-                           </div>
-                           <div class="control-group">
-                               <label for="delay-wet">Delay: Mezcla <span id="delay-wet-value">0</span></label>
-                               <input type="range" id="delay-wet" min="0" max="1" value="0" step="0.01" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
-                           </div>
-                       </div>
-                   </div>
-                   <!-- Modulación -->
-                   <div>
-                       <h4 class="font-bold text-sm text-gray-400 mb-2 border-b border-gray-700 pb-1">Modulación</h4>
-                       <div class="space-y-3 text-xs p-2">
-                           <div class="control-group">
-                               <label for="chorus-frequency">Chorus: Frecuencia <span id="chorus-frequency-value">4</span> Hz</label>
-                               <input type="range" id="chorus-frequency" min="0.1" max="10" value="4" step="0.1" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
-                           </div>
-                           <div class="control-group">
-                               <label for="chorus-depth">Chorus: Profundidad <span id="chorus-depth-value">0.5</span></label>
-                               <input type="range" id="chorus-depth" min="0" max="1" value="0.5" step="0.01" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
-                           </div>
-                           <div class="control-group">
-                               <label for="chorus-wet">Chorus: Mezcla <span id="chorus-wet-value">0</span></label>
-                               <input type="range" id="chorus-wet" min="0" max="1" value="0" step="0.01" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
-                           </div>
-                       </div>
-                   </div>
-                   <!-- Saturación -->
-                   <div>
-                       <h4 class="font-bold text-sm text-gray-400 mb-2 border-b border-gray-700 pb-1">Saturación</h4>
-                       <div class="space-y-3 text-xs p-2">
-                           <div class="control-group">
-                               <label for="distortion-amount">Distorsión <span id="distortion-amount-value">0</span></label>
-                               <input type="range" id="distortion-amount" min="0" max="1" value="0" step="0.01" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
-                           </div>
-                       </div>
-                   </div>
-                </div>
-                <div class="col-span-3 flex flex-col items-center gap-2 pt-4 border-t border-gray-700 mt-4">
-                   <label for="repeats-input" class="text-sm font-bold">REPETICIONES (AL GUARDAR)</label>
-                   <input id="repeats-input" type="number" min="1" max="10" value="1" class="bg-gray-900 text-white text-center rounded-md p-2 w-24 border border-gray-600">
-               </div>
-           </div>
-
-            <!-- RIGHT PANEL: MAIN HORIZONTAL LAYOUT -->
+            <!-- MAIN HORIZONTAL LAYOUT PANEL -->
             <div id="center-panel" class="col-span-9 bg-black/20 rounded-lg flex flex-col gap-4 p-4">
 
-                <!-- TOP SECTION (30%) -->
-                <div class="h-[30%] flex flex-col gap-4">
-                    <div id="waveform-container" class="rounded-lg w-full relative flex-grow">
+                <!-- TOP SECTION -->
+                <div class="flex flex-col gap-4 flex-shrink-0">
+                    <div id="waveform-container" class="rounded-lg w-full relative h-24">
                         <canvas id="progress-canvas"></canvas>
                         <canvas id="waveform-canvas"></canvas>
                         <div id="placeholder-text" class="absolute inset-0 text-center text-gray-500 h-full flex items-center justify-center">
                             <p>Abre un archivo o graba para comenzar</p>
                         </div>
                     </div>
-                    <div id="player-controls-bar" class="flex items-center justify-between gap-4 p-2 bg-black/30 rounded-lg flex-shrink-0">
+                    <div id="player-controls-bar" class="flex items-center justify-between gap-4 p-2 bg-black/30 rounded-lg">
                         <span id="current-time" class="w-12 text-center text-gray-400 text-sm">0:00</span>
                         <div class="flex-grow flex items-center justify-center gap-4">
                             <button id="restart-button" title="Reiniciar" class="w-10 h-10 text-lg text-white rounded-full hover:bg-white/10 transition"><i class="fas fa-undo"></i></button>
@@ -167,8 +57,8 @@
                     </div>
                 </div>
 
-                <!-- BOTTOM SECTION (70%) -->
-                <div class="h-[70%] flex flex-col gap-4">
+                <!-- BOTTOM SECTION (FLEX-GROW) -->
+                <div class="flex flex-col gap-4 flex-grow min-h-0">
                     <div id="dj-disk-container" class="bg-black/30 rounded-lg p-4 relative flex flex-col justify-center items-center flex-grow">
                         <div id="dj-disk" class="relative disk-skin-1">
                             <div id="disk-handle"></div>
@@ -208,6 +98,116 @@
                             </div>
                         </div>
                     </div>
+                </div>
+            </div>
+
+            <!-- RIGHT PANEL: MIXER -->
+            <div id="mixer-panel" class="col-span-3 bg-black/20 rounded-lg p-4 overflow-y-auto">
+                 <h3 class="font-bold text-center mb-4">Mesa de Mezclas</h3>
+                 <!-- FX CONTROLS WILL BE ADDED HERE -->
+                 <div id="fx-controls-container" class="space-y-4">
+                    <!-- Dinámica -->
+                    <div>
+                        <h4 class="font-bold text-sm text-gray-400 mb-2 border-b border-gray-700 pb-1">Dinámica</h4>
+                        <div class="space-y-3 text-xs p-2">
+                            <div class="control-group">
+                                <label for="compressor-threshold">Compresor: Umbral <span id="compressor-threshold-value">-24</span> dB</label>
+                                <input type="range" id="compressor-threshold" min="-100" max="0" value="-24" step="1" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                            </div>
+                            <div class="control-group">
+                                <label for="compressor-ratio">Compresor: Ratio <span id="compressor-ratio-value">12</span>:1</label>
+                                <input type="range" id="compressor-ratio" min="1" max="20" value="12" step="1" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                            </div>
+                            <div class="control-group">
+                                <label for="compressor-attack">Compresor: Ataque <span id="compressor-attack-value">0.003</span>s</label>
+                                <input type="range" id="compressor-attack" min="0.001" max="1" value="0.003" step="0.001" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                            </div>
+                             <div class="control-group">
+                                <label for="compressor-release">Compresor: Relajación <span id="compressor-release-value">0.25</span>s</label>
+                                <input type="range" id="compressor-release" min="0.01" max="1" value="0.25" step="0.01" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                            </div>
+                            <div class="control-group">
+                                <label for="gate-threshold">Puerta de Ruido: Umbral <span id="gate-threshold-value">-40</span> dB</label>
+                                <input type="range" id="gate-threshold" min="-100" max="0" value="-40" step="1" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Ecualizador -->
+                    <div>
+                        <h4 class="font-bold text-sm text-gray-400 mb-2 border-b border-gray-700 pb-1">Ecualizador (3-Band)</h4>
+                         <div class="space-y-3 text-xs p-2">
+                            <div class="control-group">
+                                <label for="eq-low">Graves <span id="eq-low-value">0</span> dB</label>
+                                <input type="range" id="eq-low" min="-24" max="12" value="0" step="1" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                            </div>
+                            <div class="control-group">
+                                <label for="eq-mid">Medios <span id="eq-mid-value">0</span> dB</label>
+                                <input type="range" id="eq-mid" min="-24" max="12" value="0" step="1" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                            </div>
+                            <div class="control-group">
+                                <label for="eq-high">Agudos <span id="eq-high-value">0</span> dB</label>
+                                <input type="range" id="eq-high" min="-24" max="12" value="0" step="1" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Tiempo y Espacio -->
+                    <div>
+                        <h4 class="font-bold text-sm text-gray-400 mb-2 border-b border-gray-700 pb-1">Tiempo y Espacio</h4>
+                         <div class="space-y-3 text-xs p-2">
+                            <div class="control-group">
+                                <label for="reverb-decay">Reverb: Duración <span id="reverb-decay-value">1.5</span>s</label>
+                                <input type="range" id="reverb-decay" min="0.1" max="10" value="1.5" step="0.1" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                            </div>
+                            <div class="control-group">
+                                <label for="reverb-wet">Reverb: Mezcla <span id="reverb-wet-value">0</span></label>
+                                <input type="range" id="reverb-wet" min="0" max="1" value="0" step="0.01" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                            </div>
+                            <div class="control-group">
+                                <label for="delay-time">Delay: Tiempo <span id="delay-time-value">0.5</span>s</label>
+                                <input type="range" id="delay-time" min="0" max="1" value="0.5" step="0.01" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                            </div>
+                            <div class="control-group">
+                                <label for="delay-feedback">Delay: Repeticiones <span id="delay-feedback-value">0.5</span></label>
+                                <input type="range" id="delay-feedback" min="0" max="0.9" value="0.5" step="0.01" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                            </div>
+                            <div class="control-group">
+                                <label for="delay-wet">Delay: Mezcla <span id="delay-wet-value">0</span></label>
+                                <input type="range" id="delay-wet" min="0" max="1" value="0" step="0.01" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Modulación -->
+                    <div>
+                        <h4 class="font-bold text-sm text-gray-400 mb-2 border-b border-gray-700 pb-1">Modulación</h4>
+                        <div class="space-y-3 text-xs p-2">
+                            <div class="control-group">
+                                <label for="chorus-frequency">Chorus: Frecuencia <span id="chorus-frequency-value">4</span> Hz</label>
+                                <input type="range" id="chorus-frequency" min="0.1" max="10" value="4" step="0.1" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                            </div>
+                            <div class="control-group">
+                                <label for="chorus-depth">Chorus: Profundidad <span id="chorus-depth-value">0.5</span></label>
+                                <input type="range" id="chorus-depth" min="0" max="1" value="0.5" step="0.01" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                            </div>
+                            <div class="control-group">
+                                <label for="chorus-wet">Chorus: Mezcla <span id="chorus-wet-value">0</span></label>
+                                <input type="range" id="chorus-wet" min="0" max="1" value="0" step="0.01" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Saturación -->
+                    <div>
+                        <h4 class="font-bold text-sm text-gray-400 mb-2 border-b border-gray-700 pb-1">Saturación</h4>
+                        <div class="space-y-3 text-xs p-2">
+                            <div class="control-group">
+                                <label for="distortion-amount">Distorsión <span id="distortion-amount-value">0</span></label>
+                                <input type="range" id="distortion-amount" min="0" max="1" value="0" step="0.01" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                            </div>
+                        </div>
+                    </div>
+                 </div>
+                 <div class="col-span-3 flex flex-col items-center gap-2 pt-4 border-t border-gray-700 mt-4">
+                    <label for="repeats-input" class="text-sm font-bold">REPETICIONES (AL GUARDAR)</label>
+                    <input id="repeats-input" type="number" min="1" max="10" value="1" class="bg-gray-900 text-white text-center rounded-md p-2 w-24 border border-gray-600">
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- Revert the main panel layout to place the effects mixer on the right, as originally intended.
- Adjust the flexbox properties of the main content panel to prevent the DJ disk and its controls from overflowing vertically. This ensures all content is visible on screen.