### PR TITLE
fix(estudio-sonido): Apply final layout and orientation fixes

### DIFF
--- a/estudio_de_sonido/css/main.css
+++ b/estudio_de_sonido/css/main.css
@@ -150,41 +150,6 @@ input[type="range"].w-full::-webkit-slider-thumb {
     cursor: pointer;
 }
 
-/* Estilos para la pantalla de rotación */
-#rotate-screen-overlay {
-    display: none; /* Oculto por defecto */
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: var(--bg-dark);
-    z-index: 100;
-    justify-content: center;
-    align-items: center;
-    text-align: center;
-    color: var(--text-light);
-}
-
-.rotate-screen-message {
-    padding: 20px;
-}
-
-.rotate-screen-message i {
-    font-size: 48px;
-    margin-bottom: 20px;
-}
-
-/* Media Query para modo vertical */
-@media (orientation: portrait) {
-    #rotate-screen-overlay {
-        display: flex; /* Mostrar en modo vertical */
-    }
-    .main-container {
-        display: none; /* Ocultar el contenido principal */
-    }
-}
-
 /* Disk Skin Images */
 #dj-disk.disk-skin-1 { background-image: url('../assets/imagenes/disco-1.png'); }
 #dj-disk.disk-skin-2 { background-image: url('../assets/imagenes/disco-2.png'); }

--- a/estudio_de_sonido/index.html
+++ b/estudio_de_sonido/index.html
@@ -12,14 +12,6 @@
 </head>
 <body class="flex items-center justify-center h-screen">
 
-    <!-- Pantalla de rotación -->
-    <div id="rotate-screen-overlay">
-        <div class="rotate-screen-message">
-            <i class="fas fa-sync-alt fa-spin"></i>
-            <p>Por favor, rote su dispositivo a modo horizontal para una mejor experiencia.</p>
-        </div>
-    </div>
-
     <div class="main-container rounded-2xl shadow-2xl flex flex-col overflow-hidden">
         <!-- TOP MENU BAR -->
         <div class="top-bar p-2 flex items-center gap-4 flex-shrink-0">
@@ -31,7 +23,7 @@
         </div>
 
         <!-- MAIN CONTENT GRID -->
-        <div class="flex-grow p-4 grid grid-cols-12 gap-4 overflow-hidden">
+        <div class="flex-grow p-4 grid grid-cols-12 gap-4 overflow-hidden min-h-0">
 
             <!-- MAIN HORIZONTAL LAYOUT PANEL -->
             <div id="center-panel" class="col-span-9 bg-black/20 rounded-lg flex flex-col gap-4 p-4">
@@ -59,7 +51,7 @@
 
                 <!-- BOTTOM SECTION (FLEX-GROW) -->
                 <div class="flex flex-col gap-4 flex-grow min-h-0">
-                    <div id="dj-disk-container" class="bg-black/30 rounded-lg p-4 relative flex flex-col justify-center items-center flex-grow">
+                    <div id="dj-disk-container" class="bg-black/30 rounded-lg p-4 relative flex flex-col justify-center items-center flex-grow min-h-0">
                         <div id="dj-disk" class="relative disk-skin-1">
                             <div id="disk-handle"></div>
                         </div>


### PR DESCRIPTION
- Add `min-h-0` to the main grid container and the DJ disk container to fix flexbox overflow issues, ensuring all controls are visible.
- Remove the CSS/HTML for the 'rotate device' overlay, relying solely on the JavaScript Screen Orientation API to enforce landscape mode, as requested by the user.