### PR TITLE
feat(estudio-sonido): Refactor layout to a two-panel design

### DIFF
--- a/estudio_de_sonido/css/main.css
+++ b/estudio_de_sonido/css/main.css
@@ -13,12 +13,34 @@ body {
     font-family: 'Inter', sans-serif;
     overflow: hidden;
 }
-.main-container {
-    background: var(--bg-panel);
-    border: 1px solid var(--border-color);
-    height: 95vh;
-    width: 95vw;
+
+/* NEW LAYOUT STYLES */
+#container {
+  display: flex;
+  flex-direction: row;
+  height: 100vh;
+  width: 100vw;
+  padding: 1rem;
+  gap: 1rem;
 }
+
+#main-panel {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+  gap: 1rem;
+}
+
+#right-panel {
+  width: 320px; /* adjusted for padding */
+  overflow-y: auto;
+  max-height: 100vh;
+  padding-right: 10px; /* For scrollbar */
+}
+
+/* Keep old component styles, remove old layout styles */
 .top-bar {
     background: rgba(12, 12, 20, 0.8);
     border-bottom: 1px solid var(--border-color);

--- a/estudio_de_sonido/index.html
+++ b/estudio_de_sonido/index.html
@@ -10,24 +10,22 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.7.77/Tone.js"></script>
     <link rel="stylesheet" href="css/main.css">
 </head>
-<body class="flex items-center justify-center h-screen">
+<body>
 
-    <div class="main-container rounded-2xl shadow-2xl flex flex-col overflow-hidden">
-        <!-- TOP MENU BAR -->
-        <div class="top-bar p-2 flex items-center gap-4 flex-shrink-0">
-            <h2 class="text-xl font-bold text-white pl-2">Jusn38 Studio</h2>
-            <input type="file" id="audio-upload" class="hidden" accept="audio/*">
-            <button id="open-file-btn" class="menu-btn px-3 py-1 rounded-md text-sm"><i class="fas fa-folder-open mr-2"></i>Abrir</button>
-            <button id="save-file-btn" class="menu-btn px-3 py-1 rounded-md text-sm"><i class="fas fa-save mr-2"></i>Guardar</button>
-            <span id="recording-indicator" class="hidden text-sm text-red-400 font-bold">Grabando...</span>
-        </div>
+    <div id="container">
+        <!-- LEFT PANEL: MAIN CONTROLS -->
+        <div id="main-panel">
+            <!-- TOP MENU BAR -->
+            <div class="top-bar p-2 flex items-center gap-4 flex-shrink-0 w-full mb-4">
+                <h2 class="text-xl font-bold text-white pl-2">Jusn38 Studio</h2>
+                <input type="file" id="audio-upload" class="hidden" accept="audio/*">
+                <button id="open-file-btn" class="menu-btn px-3 py-1 rounded-md text-sm"><i class="fas fa-folder-open mr-2"></i>Abrir</button>
+                <button id="save-file-btn" class="menu-btn px-3 py-1 rounded-md text-sm"><i class="fas fa-save mr-2"></i>Guardar</button>
+                <span id="recording-indicator" class="hidden text-sm text-red-400 font-bold">Grabando...</span>
+            </div>
 
-        <!-- MAIN CONTENT GRID -->
-        <div class="flex-grow p-4 grid grid-cols-12 gap-4 overflow-hidden min-h-0">
-
-            <!-- MAIN HORIZONTAL LAYOUT PANEL -->
-            <div id="center-panel" class="col-span-9 bg-black/20 rounded-lg flex flex-col gap-4 p-4">
-
+            <!-- Waveform, Player, and DJ Disk -->
+            <div id="center-panel" class="w-full h-full bg-black/20 rounded-lg flex flex-col gap-4 p-4">
                 <!-- TOP SECTION -->
                 <div class="flex flex-col gap-4 flex-shrink-0">
                     <div id="waveform-container" class="rounded-lg w-full relative h-24">
@@ -48,7 +46,6 @@
                         <span id="total-time" class="w-12 text-center text-gray-400 text-sm">0:00</span>
                     </div>
                 </div>
-
                 <!-- BOTTOM SECTION (FLEX-GROW) -->
                 <div class="flex flex-col gap-4 flex-grow min-h-0">
                     <div id="dj-disk-container" class="bg-black/30 rounded-lg p-4 relative flex flex-col justify-center items-center flex-grow min-h-0">
@@ -59,7 +56,6 @@
                     </div>
                     <div id="disk-customization-panel" class="bg-black/30 rounded-lg p-2 text-xs flex-shrink-0">
                         <div class="grid grid-cols-2 gap-2">
-                            <!-- Light Controls -->
                             <div class="flex flex-col items-center">
                                 <label class="font-bold mb-1">Color de Luz</label>
                                 <div class="flex justify-center items-center gap-2 flex-wrap">
@@ -72,7 +68,6 @@
                                     <button data-color="purple" class="color-switcher w-6 h-6 rounded-full bg-purple-500 border-2 border-gray-700 hover:border-white"></button>
                                 </div>
                             </div>
-                            <!-- Skin Controls -->
                             <div class="flex flex-col items-center">
                                 <label class="font-bold mb-1">Apariencia Disco</label>
                                 <div class="flex justify-center items-center gap-2">
@@ -82,7 +77,6 @@
                                     <button data-skin="4" class="skin-switcher w-6 h-6 rounded-full bg-gray-500 border-2 border-gray-700 hover:border-white">4</button>
                                 </div>
                             </div>
-                            <!-- Party Mode Button -->
                             <div class="col-span-2 mt-2">
                                 <button id="party-mode-btn" class="w-full py-1 bg-purple-600 rounded-md hover:bg-purple-700 transition text-white font-bold text-xs">
                                     <i class="fas fa-magic mr-1"></i>Modo Fiesta
@@ -92,11 +86,12 @@
                     </div>
                 </div>
             </div>
+        </div>
 
-            <!-- RIGHT PANEL: MIXER -->
-            <div id="mixer-panel" class="col-span-3 bg-black/20 rounded-lg p-4 overflow-y-auto">
+        <!-- RIGHT PANEL: MIXER -->
+        <div id="right-panel">
+            <div id="mixer-panel" class="bg-black/20 rounded-lg p-4 h-full">
                  <h3 class="font-bold text-center mb-4">Mesa de Mezclas</h3>
-                 <!-- FX CONTROLS WILL BE ADDED HERE -->
                  <div id="fx-controls-container" class="space-y-4">
                     <!-- Dinámica -->
                     <div>


### PR DESCRIPTION
> - Restructures the HTML to use a new flexbox-based layout with a fixed main panel on the left and a scrollable mixer panel on the right, as per detailed user instructions.

- Replaces old layout CSS with new, cleaner styles for the two-panel design.
- Ensures the application attempts to lock into landscape mode directly, removing the old 'rotate device' overlay.