### PR TITLE
feat(estudio-sonido): Increase DJ disk size

### DIFF
--- a/estudio_de_sonido/css/main.css
+++ b/estudio_de_sonido/css/main.css
@@ -108,8 +108,8 @@ input[type="range"][orient="vertical"]::-webkit-slider-thumb {
 #dj-disk-container { display: flex; flex-direction: column; justify-content: center; align-items: center; }
 #dj-disk {
     position: relative;
-    width: 250px;
-    height: 250px;
+    width: 320px;
+    height: 320px;
     background: radial-gradient(circle, #4b5563 0%, #1f2937 70%);
     border-radius: 50%;
     border: 5px solid #374151;


### PR DESCRIPTION
- Increases the width and height of the #dj-disk element from 250px to 320px to make it larger and better fit its container, as requested by the user.