### PR TITLE
fix(caja-herramientas): Fix video compressor UI

### DIFF
--- a/caja_de_herramientas/compresor_video.html
+++ b/caja_de_herramientas/compresor_video.html
@@ -12,7 +12,7 @@
 
     <div class="container mx-auto p-4">
         <header class="flex justify-between items-center p-4 bg-gray-800 rounded-lg shadow-lg mb-8">
-            <h1 class="text-2xl font-bold">Compresor de Video</h1>
+            <h1 class="text-2xl font-bold">Jusn38 Studio - Compresor Video</h1>
             <a href="index.html" class="text-gray-400 hover:text-white">
                 <i class="fas fa-toolbox fa-2x"></i>
             </a>
@@ -20,7 +20,7 @@
 
         <main>
             <div id="drop-zone" class="border-4 border-dashed border-gray-600 rounded-lg p-16 text-center cursor-pointer hover:border-purple-500 hover:bg-gray-800 transition-colors">
-                <div class="flex flex-col items-center">
+                <div class="flex flex-col items-center pointer-events-none">
                     <i class="fas fa-file-video fa-4x text-gray-500 mb-4"></i>
                     <p class="text-lg">Arrastra y suelta un archivo de video aquí</p>
                     <p class="text-gray-500">o haz clic para seleccionar un archivo</p>


### PR DESCRIPTION
- Changes the header title of the video compressor to 'Jusn38 Studio - Compresor Video' for brand consistency.
- Fixes a bug where clicking the drop zone did not open the file dialog by adding `pointer-events-none` to the child elements, ensuring the click event is captured by the correct parent.