### PR TITLE
fix: Correct event listener for spritesheet cropping

### DIFF
--- a/generador_sprites.html
+++ b/generador_sprites.html
@@ -861,8 +861,7 @@
             spritesheetCropBox.style.height = `${spritesheetCrop.height}px`;
         }
 
-        exportPreviewContainer.addEventListener('mousedown', (e) => {
-            if (!isSpritesheetCropMode || e.target === exportPreviewCanvas) return;
+        spritesheetCropBox.addEventListener('mousedown', (e) => {
             e.preventDefault();
             spritesheetCropAction.active = true;
             spritesheetCropAction.startX = e.clientX;


### PR DESCRIPTION
This commit fixes a bug where the spritesheet crop box was not interactive.

The `mousedown` event listener was previously attached to the parent container (`exportPreviewContainer`) instead of the crop box itself (`spritesheetCropBox`). This caused the event to not fire correctly, preventing the user from moving or resizing the crop area.

The listener has been moved to the correct element, and a redundant conditional check has been removed, resolving the issue.