### PR TITLE
Feat: Make crop mode and aspect ratio checkbox persistent

### DIFF
--- a/generador_sprites.html
+++ b/generador_sprites.html
@@ -614,7 +614,6 @@
             editFrameWidthInput.value = frameData.canvas.width;
             editFrameHeightInput.value = frameData.canvas.height;
             currentFrameAspectRatio = frameData.canvas.width / frameData.canvas.height;
-            editFrameAspectCheckbox.checked = true;
 
             editFrameModal.dataset.frameId = frameId;
             editFrameModal.classList.add('active');
@@ -736,10 +735,6 @@
 
         cancelExportBtn.addEventListener('click', () => {
             exportModal.classList.remove('active');
-            isSpritesheetCropMode = false;
-            spritesheetCropBox.style.display = 'none';
-            toggleSpritesheetCropBtn.classList.remove('btn-primary', 'btn-secondary');
-            toggleSpritesheetCropBtn.classList.add('btn-secondary');
         });
 
         const allExportInputs = [exportCountInput, exportPaddingInput, exportPresetSelect, exportLayoutSelect];


### PR DESCRIPTION
Based on user feedback, this commit introduces two quality-of-life improvements:

1.  The "Crop Spritesheet" mode in the export modal now persists even if the modal is closed and reopened. The `cancelExportBtn` event listener was modified to only hide the modal, without resetting the crop state.

2.  The "Keep aspect ratio" checkbox in the "Edit Frame" modal now remembers its state between uses. The line that reset the checkbox to `checked` every time the modal was opened has been removed.