### PR TITLE
Feat: Clarify crop and download button labels

### DIFF
--- a/generador_sprites.html
+++ b/generador_sprites.html
@@ -731,6 +731,7 @@
             }
             exportModal.classList.add('active');
             generateSpritesheetPreview();
+            updateCropButtonTexts(isSpritesheetCropMode);
         });
 
         cancelExportBtn.addEventListener('click', () => {
@@ -845,12 +846,25 @@
             }
         }
 
+        function updateCropButtonTexts(isCropping) {
+            if (isCropping) {
+                toggleSpritesheetCropBtn.innerHTML = `<i class="fas fa-times mr-2"></i>Cancelar Recorte`;
+                downloadSpritesheetBtn.innerHTML = `<i class="fas fa-crop-alt mr-2"></i>Descargar con Recorte`;
+            } else {
+                toggleSpritesheetCropBtn.innerHTML = `<i class="fas fa-crop-alt mr-2"></i>Recortar Spritesheet`;
+                downloadSpritesheetBtn.innerHTML = `<i class="fas fa-download mr-2"></i>Descargar Spritesheet`;
+            }
+        }
+
         // --- Spritesheet Cropping Logic ---
         toggleSpritesheetCropBtn.addEventListener('click', () => {
             isSpritesheetCropMode = !isSpritesheetCropMode;
             spritesheetCropBox.style.display = isSpritesheetCropMode ? 'block' : 'none';
             toggleSpritesheetCropBtn.classList.toggle('btn-primary', isSpritesheetCropMode);
             toggleSpritesheetCropBtn.classList.toggle('btn-secondary', !isSpritesheetCropMode);
+
+            updateCropButtonTexts(isSpritesheetCropMode);
+
             if (isSpritesheetCropMode) {
                 const previewRect = exportPreviewCanvas.getBoundingClientRect();
                 const containerRect = exportPreviewContainer.getBoundingClientRect();


### PR DESCRIPTION
To make the cropping workflow more intuitive, the text of the cropping and download buttons now dynamically updates based on the application's state.

- A new `updateCropButtonTexts` function has been created to manage the button labels.
- When crop mode is activated, the "Recortar Spritesheet" button changes to "Cancelar Recorte" and the "Descargar Spritesheet" button changes to "Descargar con Recorte".
- The button labels revert to their original state when crop mode is deactivated.
- This behavior is now consistent even when closing and reopening the export modal.