### PR TITLE
feat: Add horizontal orientation lock

### DIFF
--- a/lumenfall/css/style.css
+++ b/lumenfall/css/style.css
@@ -632,3 +632,37 @@ html, body {
     color: white;
     border: 2px solid white;
 }
+
+/* --- Estilos para el bloqueo de orientación --- */
+#rotate-device-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: #000;
+    color: #fff;
+    z-index: 9999;
+    display: none; /* Oculto por defecto */
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    font-family: 'Cinzel', serif;
+    font-size: 1.5em;
+}
+
+.rotate-device-message {
+    padding: 20px;
+}
+
+/* Media Query para modo retrato */
+@media (orientation: portrait) {
+    #rotate-device-overlay {
+        display: flex;
+    }
+
+    /* Ocultar todo lo demás */
+    body > *:not(#rotate-device-overlay) {
+        display: none !important;
+    }
+}

--- a/lumenfall/index.html
+++ b/lumenfall/index.html
@@ -114,5 +114,11 @@
         <button id="quit-button">Salir</button>
     </div>
     <script src="js/game.js"></script>
+
+    <div id="rotate-device-overlay">
+        <div class="rotate-device-message" data-translate-key="rotateDevice">
+            Por favor, gira tu dispositivo a modo horizontal.
+        </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
Adds an overlay that is displayed when the device is in portrait mode, instructing the user to rotate it to landscape.

This is implemented using a CSS media query (`orientation: portrait`).

- Modifies `index.html` to include the overlay element.
- Modifies `style.css` to add the required styles for the overlay and the media query.