### PR TITLE
Fix square shadow on characters

### DIFF
--- a/lumenfall/js/game.js
+++ b/lumenfall/js/game.js
@@ -746,7 +746,7 @@
                 const playerWidth = 2.8;
 
                 const playerGeometry = new THREE.PlaneGeometry(playerWidth, playerHeight);
-                const playerMaterial = new THREE.MeshStandardMaterial({ map: this.runningTexture, transparent: true, side: THREE.DoubleSide, alphaTest: 0.5 });
+                const playerMaterial = new THREE.MeshStandardMaterial({ map: this.runningTexture, transparent: true, side: THREE.DoubleSide, alphaTest: 0.1 });
                 this.mesh = new THREE.Mesh(playerGeometry, playerMaterial);
                 this.mesh.position.y = playerHeight / 2;
                 this.mesh.castShadow = true;
@@ -1349,7 +1349,7 @@
                 const enemyMaterial = new THREE.MeshStandardMaterial({
                     map: this.texture,
                     transparent: true,
-                    alphaTest: 0.5,
+                    alphaTest: 0.1,
                     side: THREE.DoubleSide
                 });
                 const enemyGeometry = new THREE.PlaneGeometry(enemyWidth, enemyHeight);


### PR DESCRIPTION
The character and enemy shadows were appearing as squares instead of conforming to the sprite's outline. This was because the `alphaTest` value on the material was not configured correctly.

- Changed `alphaTest` from `0.5` to `0.1` for the player and simple enemy materials in `lumenfall/js/game.js`. This ensures that transparent pixels in the sprite texture are not included when casting shadows, resulting in a correctly shaped shadow.