### PR TITLE
Temporarily changed the floor texture to use the wall texture. This i…

### DIFF
--- a/lumenfall/js/game.js
+++ b/lumenfall/js/game.js
@@ -994,7 +994,7 @@
         const wallMaterial = new THREE.MeshStandardMaterial({ map: wallTexture, color: 0x454555 });
         const doorTexture = textureLoader.load(assetUrls.doorTexture);
         const doorMaterial = new THREE.MeshStandardMaterial({ map: doorTexture, transparent: true, alphaTest: 0.5 });
-        const floorTexture = textureLoader.load(assetUrls.floorTexture);
+        const floorTexture = textureLoader.load(assetUrls.wallTexture);
         floorTexture.wrapS = floorTexture.wrapT = THREE.RepeatWrapping;
         floorTexture.repeat.set(playableAreaWidth / 4, roomDepth / 5);
         const floorMaterial = new THREE.MeshStandardMaterial({ map: floorTexture });


### PR DESCRIPTION
…s to help debug an issue where the floor texture is not appearing. By using a known-working texture (the wall texture), the user can determine if the issue is with the floor texture image file itself or with the game's code.