### PR TITLE
feat: Improve projectile visuals and add fade-out effect

### DIFF
--- a/lumenfall/js/game.js
+++ b/lumenfall/js/game.js
@@ -222,7 +222,11 @@
             }
 
             interactPressed = false;
-            allFlames.forEach(flame => flame.update(deltaTime));
+            for (let i = allFlames.length - 1; i >= 0; i--) {
+                if (!allFlames[i].update(deltaTime)) {
+                    allFlames.splice(i, 1);
+                }
+            }
             allSpecters.forEach(specter => specter.update(deltaTime, player));
             allSimpleEnemies.forEach(enemy => enemy.update(deltaTime));
             allPuzzles.forEach(puzzle => puzzle.update(deltaTime));
@@ -1173,11 +1177,13 @@
         };
 
         class RealisticFlame {
-            constructor(scene, position) {
+            constructor(scene, position, lifetime = -1) {
                 this.scene = scene;
                 this.position = position;
                 this.particleCount = 20;
                 this.velocities = [];
+                this.lifetime = lifetime; // -1 para vida infinita (antorchas)
+                this.initialLifetime = lifetime;
                 this.init();
             }
 
@@ -1201,6 +1207,21 @@
             }
 
             update(deltaTime) {
+                if (this.lifetime > 0) {
+                    this.lifetime -= deltaTime;
+                    if (this.lifetime <= 0) {
+                        this.scene.remove(this.particles);
+                        this.scene.remove(this.light);
+                        return false; // Indicar que la llama ha expirado
+                    }
+                    // Desvanecimiento
+                    const fade = this.lifetime / this.initialLifetime;
+                    this.particles.material.opacity = fade;
+                    this.light.intensity = (1.0 + Math.sin(Date.now() * 0.01 + this.position.x) * 0.5) * fade;
+                } else {
+                     this.light.intensity = 1.0 + Math.sin(Date.now() * 0.01 + this.position.x) * 0.5;
+                }
+
                 const positions = this.particles.geometry.attributes.position.array;
                 for (let i = 0; i < this.particleCount; i++) {
                     const vel = this.velocities[i];
@@ -1217,7 +1238,7 @@
                     positions[i * 3 + 2] += vel.z;
                 }
                 this.particles.geometry.attributes.position.needsUpdate = true;
-                this.light.intensity = 1.0 + Math.sin(Date.now() * 0.01 + this.position.x) * 0.5;
+                return true; // La llama sigue activa
             }
         }
 
@@ -1577,7 +1598,7 @@
             update(deltaTime) {
                 this.lifetime -= deltaTime;
                 if (this.lifetime <= 0) {
-                    allFlames.push(new RealisticFlame(this.scene, this.mesh.position));
+                    allFlames.push(new RealisticFlame(this.scene, this.mesh.position, 3));
                     return false;
                 }
                 this.mesh.position.x += this.velocity.x;
@@ -1585,7 +1606,7 @@
 
                 // Wall collision
                 if (this.mesh.position.x < player.minPlayerX || this.mesh.position.x > player.maxPlayerX) {
-                    allFlames.push(new RealisticFlame(this.scene, this.mesh.position));
+                    allFlames.push(new RealisticFlame(this.scene, this.mesh.position, 3));
                     this.lifetime = 0;
                     return false;
                 }
@@ -1594,7 +1615,7 @@
                 for (const enemy of allSimpleEnemies) {
                     if (this.mesh.position.distanceTo(enemy.mesh.position) < (enemy.mesh.geometry.parameters.height / 2)) {
                         enemy.takeHit();
-                        allFlames.push(new RealisticFlame(this.scene, this.mesh.position));
+                        allFlames.push(new RealisticFlame(this.scene, this.mesh.position, 3));
                         this.lifetime = 0; // Mark for removal
                         return false; // Projectile disappears
                     }


### PR DESCRIPTION
- Doubles the size of the projectile.
- Fixes a transparency issue with the player sprite.
- Replaces the projectile impact effect with the existing `RealisticFlame` effect for visual consistency.
- Adds a 3-second lifetime to the impact flame effect, causing it to fade out and disappear after impact.