### PR TITLE
feat(options): Add scrollbar to options menu

### DIFF
--- a/lumenfall/css/style.css
+++ b/lumenfall/css/style.css
@@ -411,18 +411,45 @@ html, body {
             background-color: rgba(0, 0, 0, 0.8);
             display: none;
             flex-direction: column;
-            justify-content: center;
+            justify-content: space-around; /* Changed from center */
             align-items: center;
             z-index: 102;
             color: white;
             opacity: 0;
             transition: opacity 0.3s ease-in;
             text-align: center;
+            padding: 5vh 0; /* Added padding */
+            box-sizing: border-box; /* Added for better padding behavior */
         }
 
         #pause-menu.active {
             display: flex;
             opacity: 1;
+        }
+
+        .pause-menu-content {
+            overflow-y: auto;
+            /* max-height: 70vh; */ /* Let's let the flexbox handle the height */
+            width: 100%;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            padding: 20px 0;
+            scrollbar-width: thin;
+            scrollbar-color: #3498db rgba(0,0,0,0.5);
+        }
+
+        /* For Webkit browsers */
+        .pause-menu-content::-webkit-scrollbar {
+            width: 8px;
+        }
+        .pause-menu-content::-webkit-scrollbar-track {
+            background: rgba(0,0,0,0.5);
+            border-radius: 4px;
+        }
+        .pause-menu-content::-webkit-scrollbar-thumb {
+            background-color: #3498db;
+            border-radius: 4px;
         }
 
         .menu-item {

--- a/lumenfall/index.html
+++ b/lumenfall/index.html
@@ -71,29 +71,31 @@
 
     <div id="pause-menu">
         <h2 data-translate-key="settings">Configuración</h2>
-        <div class="menu-item">
-            <p data-translate-key="languageLabel">Idioma:</p>
-            <select id="pause-language-select">
-                <option value="es">Español</option>
-                <option value="en">English</option>
-            </select>
-        </div>
-
-        <button id="gamepad-toggle" class="pause-button" data-translate-key="activateGamepad">Activar Control</button>
-
-        <button id="vibration-toggle" class="pause-button" data-translate-key="toggleVibrationOn">Vibración: ON</button>
-
-        <div class="audio-control-panel">
-            <h3 data-translate-key="audioControls">Controles de Audio</h3>
-            <div class="audio-control">
-                <span data-translate-key="musicVolume">Música Ambiental:</span>
-                <button id="music-toggle">▶</button>
-                <input type="range" id="music-volume" class="slider" min="0" max="1" step="0.1" value="0.5">
+        <div class="pause-menu-content">
+            <div class="menu-item">
+                <p data-translate-key="languageLabel">Idioma:</p>
+                <select id="pause-language-select">
+                    <option value="es">Español</option>
+                    <option value="en">English</option>
+                </select>
             </div>
-            <div class="audio-control">
-                <span data-translate-key="sfxVolume">Pasos:</span>
-                <button id="sfx-toggle">▶</button>
-                <input type="range" id="sfx-volume" class="slider" min="0" max="1" step="0.1" value="0.5">
+
+            <button id="gamepad-toggle" class="pause-button" data-translate-key="activateGamepad">Activar Control</button>
+
+            <button id="vibration-toggle" class="pause-button" data-translate-key="toggleVibrationOn">Vibración: ON</button>
+
+            <div class="audio-control-panel">
+                <h3 data-translate-key="audioControls">Controles de Audio</h3>
+                <div class="audio-control">
+                    <span data-translate-key="musicVolume">Música Ambiental:</span>
+                    <button id="music-toggle">▶</button>
+                    <input type="range" id="music-volume" class="slider" min="0" max="1" step="0.1" value="0.5">
+                </div>
+                <div class="audio-control">
+                    <span data-translate-key="sfxVolume">Pasos:</span>
+                    <button id="sfx-toggle">▶</button>
+                    <input type="range" id="sfx-volume" class="slider" min="0" max="1" step="0.1" value="0.5">
+                </div>
             </div>
         </div>
         <button id="resume-button" class="close-btn" data-translate-key="resume">Reanudar</button>


### PR DESCRIPTION
Adds a scrollbar to the pause/options menu.

The game was recently changed from portrait to landscape mode, which caused some of the options in the menu to be cut off at the bottom of the screen.

This change wraps the menu items in a scrollable container (`div.pause-menu-content`) and applies the necessary CSS to enable vertical scrolling when the content overflows. This ensures that all current and future options are accessible to the user.