### PR TITLE
feat: Add LumenFall book screen to carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,6 +209,21 @@
                 </div>
             </div>
         </a>
+
+        <!-- Panel 10: LumenFall book -->
+        <a href="LumenFall-book/" class="project-card-3d">
+            <div class="glass-card rounded-lg w-full h-full">
+                <video class="card-video-bg" autoplay loop muted playsinline><source src="LumenFall-book/assets/videos/video-1.mp4" type="video/mp4"></video>
+                <div class="card-content p-6 text-center">
+                    <div class="flex justify-center mb-4"><svg class="w-12 h-12 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path d="M10.575 2.25h2.85c.414 0 .75.336.75.75v.31c0 .414-.336.75-.75.75h-2.85a.75.75 0 01-.75-.75v-.31c0-.414.336.75.75-.75zM9 9.75A.75.75 0 009.75 9h4.5a.75.75 0 000-1.5h-4.5A.75.75 0 009 9.75zM9 12.75A.75.75 0 009.75 12h4.5a.75.75 0 000-1.5h-4.5a.75.75 0 00-.75.75zM9.057 15.443l-.004.005a.75.75 0 00.004-.005zM8.25 15h7.5a.75.75 0 00.75-.75v-6a.75.75 0 00-.75-.75h-7.5a.75.75 0 00-.75.75v6c0 .414.336.75.75.75zM12 21a8.25 8.25 0 008.25-8.25v-6A8.25 8.25 0 0012 3H3.75A1.5 1.5 0 002.25 4.5v12A1.5 1.5 0 003.75 18H12c0 1.657 1.343 3 3 3z" /></svg></div>
+                    <h2 class="text-xl font-bold text-white">LumenFall book</h2>
+                    <p class="text-slate-300 mt-1 text-sm">Libro interactivo de Lumenfall.</p>
+                </div>
+                <div class="monitor-bezel">
+                    <div class="loading-bar-container"><div class="loading-bar-fill"></div></div>
+                </div>
+            </div>
+        </a>
         
         <!-- Panel 2: Lumenfall -->
         <a href="lumenfall/index.html" class="project-card-3d">


### PR DESCRIPTION
Adds a new screen to the main carousel for the "LumenFall book" project.

- Creates a new panel in `index.html` with a link to the `LumenFall-book/` directory.
- Uses the video from `LumenFall-book/assets/videos/video-1.mp4` as the background for the new panel.
- Includes a title, description, and icon consistent with the other panels.