### PR TITLE
fix(LumenFall-book): Fix page navigation after zoom

### DIFF
--- a/LumenFall-book/index.html
+++ b/LumenFall-book/index.html
@@ -509,6 +509,7 @@
             zoomSlider.val(currentScale);
             updateSliderFill(zoomSlider[0]);
             localStorage.setItem('lumenFallZoom', currentScale);
+            flipbook.turn('resize');
         }
 
         zoomSlider.on('input', function() {


### PR DESCRIPTION
The page navigation buttons in the LumenFall book would become unresponsive after the user zoomed in. This was because the `turn.js` library was not aware of the CSS transform being applied to the book container, causing its click hotspots to become misaligned.

This fix addresses the issue by calling `flipbook.turn('resize')` within the `applyZoom` function. This notifies the `turn.js` library of the change in scale, allowing it to recalculate the positions of its navigation hotspots and ensuring they remain functional after zooming.