### PR TITLE
fix(LumenFall-book): Correct case for cover image filename

### DIFF
--- a/LumenFall-book/index.html
+++ b/LumenFall-book/index.html
@@ -97,7 +97,7 @@
         .flipbook .page { box-shadow: 0 4px 10px rgba(0,0,0,0.3); position: relative; overflow: hidden; }
         .flipbook .hard { background-color: #101010; box-shadow: inset 0 0 5px #000; }
         
-        .cover-page { background: #101010 url(assets/imagenes/portada-libro2.jpg) center/cover no-repeat !important; }
+        .cover-page { background: #101010 url(assets/imagenes/Portada-libro2.jpg) center/cover no-repeat !important; }
         .back-cover-page { background: #101010 url(https://raw.githubusercontent.com/Yanzsmartwood2025/JUSN38/32acf737002f499e83f4e3fb63d27b0dd4d44827/LumenFall-book/assets/imagenes/Contraportada-libro.jpg) center/contain no-repeat !important; }
         
         .page-number { position: absolute; bottom: 15px; left: 50%; transform: translateX(-50%); font-size: 1.8em; }


### PR DESCRIPTION
The previous commit used an incorrect filename for the cover image, which caused it to not be displayed. This commit corrects the filename to 'Portada-libro2.jpg' to fix the issue.