### PR TITLE
feat: Adjust carousel sensitivity

### DIFF
--- a/index.html
+++ b/index.html
@@ -858,7 +858,7 @@
             }
             
             if (isDragging) {
-                const rotationFactor = 0.002;
+                const rotationFactor = 0.001;
                 const newRotation = startRotationY + (deltaX * rotationFactor);
                 velocityY = newRotation - carouselGroup.rotation.y;
                 carouselGroup.rotation.y = newRotation;


### PR DESCRIPTION
This commit reduces the carousel's sensitivity to make it less fragile and easier to control. The `rotationFactor` in the `onPointerMove` function has been decreased from 0.002 to 0.001.

This change addresses the user's request to make the carousel less sensitive to movement.